### PR TITLE
sotd and headers.js clean-up

### DIFF
--- a/examples/logius-profile/organisation-config.js
+++ b/examples/logius-profile/organisation-config.js
@@ -116,17 +116,17 @@ const organisationConfig = {
   sotdText: {
     nl: {
       sotd: "Status van dit document",
-      def: `Dit is de definitieve versie van. Wijzigingen naar aanleiding van consultaties zijn doorgevoerd.`,
+      def: `Dit is de definitieve versie van dit document. Wijzigingen naar aanleiding van consultaties zijn doorgevoerd.`,
       wv: `Dit is een werkversie die op elk moment kan worden gewijzigd, verwijderd of vervangen door andere documenten. Het is geen door goedgekeurde consultatieversie.`,
-      cv: `Dit is een door goedgekeurde consultatieversie. Commentaar over dit document kan gestuurd worden naar `,
-      vv: `Dit is een definitief concept van de nieuwe versie van. Wijzigingen naar aanleiding van consultaties zijn doorgevoerd.`,
+      cv: `Dit is een door ?? goedgekeurde consultatieversie. Commentaar over dit document kan gestuurd worden naar ??`,
+      vv: `Dit is een definitief concept van de nieuwe versie van dit document. Wijzigingen naar aanleiding van consultaties zijn doorgevoerd.`,
       basis: "Dit is een document zonder officiële status.",
     },
     en: {
       sotd: "Status of This Document",
-      def: `This is the definitive version of the. Edits resulting from consultations have been applied.`,
+      def: `This is the definitive version of this document. Edits resulting from consultations have been applied.`,
       wv: `This is a draft that could be altered, removed or replaced by other documents. It is not a recommendation approved by.`,
-      cv: `This is a proposed recommendation approved by. Comments regarding this document may be sent to `,
+      cv: `This is a proposed recommendation approved by ??. Comments regarding this document may be sent to ??`,
       vv: `This is the definitive concept of the. Edits resulting from consultations have been applied.`,
       basis: "This document has no official standing.",
     },

--- a/package.json
+++ b/package.json
@@ -86,11 +86,9 @@
   },
   "dependencies": {
     "colors": "1.4.0",
-    "dom-compare": "^0.6.0",
     "finalhandler": "^1.2.0",
     "marked": "^4.2.4",
     "puppeteer": "^19.4.0",
-    "html-compare": "^0.0.1",
     "sade": "^1.8.1",
     "serve-static": "^1.15.0"
   },

--- a/src/logius/fix-md-elements.js
+++ b/src/logius/fix-md-elements.js
@@ -7,7 +7,7 @@ export const name = "logius/fix-md-elements";
 export function run(conf) {
   addClassTables(conf);
   addClassCode(conf);
-  addFigureImg(conf);
+  addFigureImg();
 }
 
 function addClassTables(conf) {
@@ -27,11 +27,7 @@ function addClassCode(conf) {
   }
 }
 
-function addFigureImg(conf) {
-  if (!conf.nl_markdownEmbedImageInFigure) {
-    return;
-  }
-
+function addFigureImg() {
   [...document.querySelectorAll("img")]
     .filter(img => !img.closest("figure"))
     .forEach(img => {

--- a/src/logius/missing-config-warner.js
+++ b/src/logius/missing-config-warner.js
@@ -2,15 +2,9 @@ import { showError, showWarning } from "../core/utils.js";
 
 export const name = "logius/missing-config-warner";
 
-const requiredConfigs = ["licenses"];
+const requiredConfigs = ["licenses", "license"];
 
-const recommendedConfigs = [
-  "specStatus",
-  "nl_organisationName",
-  "governanceTypeText",
-  "govTextCode",
-  "sotdText",
-];
+const recommendedConfigs = ["specStatus", "nl_organisationName", "sotdText"];
 
 const wikiURL = "https://github.com/Logius-standaarden/respec/wiki/";
 

--- a/src/logius/templates/headers.js
+++ b/src/logius/templates/headers.js
@@ -47,9 +47,11 @@ const localizationStrings = {
     prev_version: "Previous version:",
     prev_recommendation: "Previous Recommendation:",
     latest_recommendation: "Latest Recommendation:",
-	alt_format: "This document is also available in these non-normative format:",
-	alt_formats: "This document is also available in these non-normative formats:",
-	licensed: "This document is licensed under ",
+    alt_format:
+      "This document is also available in these non-normative format:",
+    alt_formats:
+      "This document is also available in these non-normative formats:",
+    licensed: "This document is licensed under ",
   },
   ko: {
     author: "저자:",
@@ -103,9 +105,11 @@ const localizationStrings = {
     prev_version: "Vorige versie",
     former_editor: "Voormalig redacteur",
     former_editors: "Voormalige redacteurs",
-	alt_format: "Dit document is ook beschikbaar in dit niet-normatieve formaat:",
-	alt_formats: "Dit document is ook beschikbaar in deze niet-normatieve formaten:",
-	licensed: "Dit document is gelicentieerd onder ",
+    alt_format:
+      "Dit document is ook beschikbaar in dit niet-normatieve formaat:",
+    alt_formats:
+      "Dit document is ook beschikbaar in deze niet-normatieve formaten:",
+    licensed: "Dit document is gelicentieerd onder ",
   },
   es: {
     author: "Autor:",
@@ -257,9 +261,7 @@ export default (conf, options) => {
       : ""}
     ${conf.alternateFormats
       ? html`<p>
-          ${options.multipleAlternates
-            ? l10n.alt_formats
-            : l10n.alt_format}
+          ${options.multipleAlternates ? l10n.alt_formats : l10n.alt_format}
           ${options.alternatesHTML}
         </p>`
       : ""}

--- a/src/logius/templates/headers.js
+++ b/src/logius/templates/headers.js
@@ -47,6 +47,9 @@ const localizationStrings = {
     prev_version: "Previous version:",
     prev_recommendation: "Previous Recommendation:",
     latest_recommendation: "Latest Recommendation:",
+	alt_format: "This document is also available in these non-normative format:",
+	alt_formats: "This document is also available in these non-normative formats:",
+	licensed: "This document is licensed under ",
   },
   ko: {
     author: "저자:",
@@ -100,6 +103,9 @@ const localizationStrings = {
     prev_version: "Vorige versie",
     former_editor: "Voormalig redacteur",
     former_editors: "Voormalige redacteurs",
+	alt_format: "Dit document is ook beschikbaar in dit niet-normatieve formaat:",
+	alt_formats: "Dit document is ook beschikbaar in deze niet-normatieve formaten:",
+	licensed: "Dit document is gelicentieerd onder ",
   },
   es: {
     author: "Autor:",
@@ -250,10 +256,10 @@ export default (conf, options) => {
         </p>`
       : ""}
     ${conf.alternateFormats
-      ? html`<p lang="en">
+      ? html`<p>
           ${options.multipleAlternates
-            ? "This document is also available in these non-normative formats:"
-            : "This document is also available in this non-normative format:"}
+            ? l10n.alt_formats
+            : l10n.alt_format}
           ${options.alternatesHTML}
         </p>`
       : ""}
@@ -289,8 +295,8 @@ function renderCopyright(conf) {
       ? html`<p class="copyright">${[conf.additionalCopyrightHolders]}</p>`
       : conf.overrideCopyright
       ? [conf.overrideCopyright]
-      : html`<p class="copyright" lang="en">
-          This document is licensed under a
+      : html`<p class="copyright">
+          ${l10n.licensed}
           ${linkLicense(
             conf.licenses[conf.license.toLowerCase()].name,
             conf.licenses[conf.license.toLowerCase()].url,

--- a/src/logius/templates/headers.js
+++ b/src/logius/templates/headers.js
@@ -109,7 +109,7 @@ const localizationStrings = {
       "Dit document is ook beschikbaar in dit niet-normatieve formaat:",
     alt_formats:
       "Dit document is ook beschikbaar in deze niet-normatieve formaten:",
-    licensed: "Dit document is gelicentieerd onder ",
+    licensed: "Dit document valt onder de volgende licentie: ",
   },
   es: {
     author: "Autor:",

--- a/src/logius/templates/sotd.js
+++ b/src/logius/templates/sotd.js
@@ -2,55 +2,16 @@
 import { getIntlData } from "../../core/utils.js";
 import { html } from "../../core/import-maps.js";
 
-export default (conf, opts) => {
+export default conf => {
   const l10n_sotdText = getIntlData(conf.sotdText);
   return html`
     <h2>${l10n_sotdText.sotd}</h2>
-    ${conf.isPreview ? renderPreview(conf) : ""}
-    ${conf.isDEF
-      ? l10n_sotdText.def
-      : conf.isVV
-      ? l10n_sotdText.vv
-      : conf.isCV
-      ? html`${l10n_sotdText.cv}<a href="${opts.emailCommentsMailto}"
-            >${opts.emailComments}</a
-          >.`
-      : conf.isWV
-      ? l10n_sotdText.wv
-      : conf.isBASIS
-      ? l10n_sotdText.basis
-      : ""}
-    ${renderGovernance(conf)}
+    ${renderSotD(conf)}
   `;
 };
 
-export function renderPreview(conf) {
-  const { prUrl, prNumber, edDraftURI } = conf;
-  return html`<details class="annoying-warning" open="">
-    <summary>
-      This is a
-      preview${prUrl && prNumber
-        ? html`
-            of pull request
-            <a href="${prUrl}">#${prNumber}</a>
-          `
-        : ""}
-    </summary>
-    <p>
-      Do not attempt to implement this version of the specification. Do not
-      reference this version as authoritative in any way.
-      ${edDraftURI
-        ? html`
-            Instead, see
-            <a href="${edDraftURI}">${edDraftURI}</a> for the Editor's draft.
-          `
-        : ""}
-    </p>
-  </details>`;
-}
-
-function renderGovernance(conf) {
-  const govTextCode = conf.govTextCode.toLowerCase();
-  const govText = getIntlData(conf.governanceTypeText)[govTextCode];
-  return html`<p>${govText}</p>`;
+function renderSotD(conf) {
+  const specStatus = conf.specStatus.toLowerCase();
+  const sotdText = getIntlData(conf.sotdText)[specStatus];
+  return html`<p>${sotdText}</p>`;
 }


### PR DESCRIPTION
Geen aparte governancetekst, omdat dit evengoed hard-coded in de SotD-tekst kan. Verder opgeruimd en build getest:
https://sanderke.github.io/respec-review/

~Logo komt nog niet in beeld.~