### PR TITLE
Localization strings

### DIFF
--- a/src/logius/headers.js
+++ b/src/logius/headers.js
@@ -234,7 +234,9 @@ export function run(conf) {
   conf.statusText = getIntlData(conf.localizationStrings)[
     conf.specStatus.toLowerCase()
   ];
-  conf.typeText = getIntlData(conf.localizationStrings)[conf.specType.toLowerCase()];
+  conf.typeText = getIntlData(conf.localizationStrings)[
+    conf.specType.toLowerCase()
+  ];
 
   conf.showThisVersion = !conf.isNoTrack; // || conf.isTagFinding;
   conf.showPreviousVersion = !conf.isNoTrack && !conf.isSubmission;

--- a/src/logius/headers.js
+++ b/src/logius/headers.js
@@ -231,10 +231,10 @@ export function run(conf) {
 
   if (conf.copyrightStart && conf.copyrightStart == conf.publishYear)
     conf.copyrightStart = "";
-  conf.statusText = getIntlData(conf.specStatusText)[
+  conf.statusText = getIntlData(conf.localizationStrings)[
     conf.specStatus.toLowerCase()
   ];
-  conf.typeText = getIntlData(conf.specTypeText)[conf.specType.toLowerCase()];
+  conf.typeText = getIntlData(conf.localizationStrings)[conf.specType.toLowerCase()];
 
   conf.showThisVersion = !conf.isNoTrack; // || conf.isTagFinding;
   conf.showPreviousVersion = !conf.isNoTrack && !conf.isSubmission;


### PR DESCRIPTION
All localization strings are expected to be in `localizationStrings` instead of also in `specStatusText` and `specTypeText`.