### PR TITLE
Vaker versienummers weergeven

### DIFF
--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -165,7 +165,10 @@ export function run(conf) {
   }
 
   if (!conf.subtitle) conf.subtitle = "";
-  conf.isNoTrack = !conf.publishDate || !conf.publishVersion || conf.specStatus?.toUpperCase() == "WV";
+  conf.isNoTrack =
+    !conf.publishDate ||
+    !conf.publishVersion ||
+    conf.specStatus?.toUpperCase() == "WV";
   conf.publishDate = validateDateAndRecover(
     conf,
     "publishDate",

--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -165,10 +165,7 @@ export function run(conf) {
   }
 
   if (!conf.subtitle) conf.subtitle = "";
-  conf.isNoTrack =
-    !conf.publishDate ||
-    !conf.publishVersion ||
-    conf.specStatus?.toUpperCase() == "WV";
+  conf.isNoTrack = !conf.publishDate || !conf.publishVersion;
   conf.publishDate = validateDateAndRecover(
     conf,
     "publishDate",

--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -165,7 +165,7 @@ export function run(conf) {
   }
 
   if (!conf.subtitle) conf.subtitle = "";
-  conf.isNoTrack = !conf.publishDate;
+  conf.isNoTrack = !conf.publishDate || !conf.publishVersion || conf.specStatus?.toUpperCase() == "WV";
   conf.publishDate = validateDateAndRecover(
     conf,
     "publishDate",
@@ -241,7 +241,6 @@ export function run(conf) {
   }
   conf.typeText = getIntlData(conf.specTypeText)[conf.specType.toLowerCase()];
 
-  conf.showThisVersion = !conf.isNoTrack; // || conf.isTagFinding;
   conf.showPreviousVersion = !conf.isNoTrack && !conf.isSubmission;
   if (!conf.prevVersion) conf.showPreviousVersion = false;
 

--- a/src/nlgov/title.js
+++ b/src/nlgov/title.js
@@ -1,7 +1,7 @@
 export const name = "logius/title";
 
 export async function run(conf) {
-  if (conf.specStatus.toUpperCase() == "DEF" && conf.publishVersion) {
+  if (!conf.isNoTrack) {
     document.title = `${document.title} ${conf.publishVersion}`;
     conf.title = `${conf.title} ${conf.publishVersion}`;
   }

--- a/src/nlgov/title.js
+++ b/src/nlgov/title.js
@@ -1,7 +1,7 @@
 export const name = "logius/title";
 
 export async function run(conf) {
-  if (!conf.isNoTrack) {
+  if (conf.specStatus.toUpperCase() != "WV" && conf.publishVersion) {
     document.title = `${document.title} ${conf.publishVersion}`;
     conf.title = `${conf.title} ${conf.publishVersion}`;
   }


### PR DESCRIPTION
Bij werkversies willen wij geen versienummer tonen, daar dit pas bij publicatie bepaald wordt. Derhalve wordt momenteel enkel bij status `DEF` een versienummer naast de titel geplaatst.
Dit wijzigingsverzoek weerhoudt het versienummer alleen als het document de status `WV` draagt. Hiermee zal een versienummer bij consultatieversies zichtbaar worden, bijvoorbeeld _2.1.0-rc.1_.