### PR TITLE
Option to preserve original casing in URL

### DIFF
--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -422,4 +422,3 @@ function populateSoTD(conf) {
   const template = sotdTmpl;
   return template(conf);
 }
-

--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -304,7 +304,7 @@ export function run(conf) {
     if (unresolved) {
       return;
     }
-    return url.toLowerCase();
+    return conf.keepCase ? url : url.toLowerCase();
   }
 
   if (!conf.thisVersion) {
@@ -423,3 +423,4 @@ function populateSoTD(conf) {
   const template = sotdTmpl;
   return template(conf);
 }
+

--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -134,6 +134,7 @@ export function run(conf) {
   }
   conf.specType = conf.specType ? conf.specType.toUpperCase() : "";
 
+  conf.pubDomain = conf.pubDomain ? conf.pubDomain.toLowerCase() : "";
   conf.hasBeenPublished = !!conf.publishDate;
 
   conf.licenseInfo = conf.licenses[conf.license.toLowerCase()];

--- a/src/nlgov/headers.js
+++ b/src/nlgov/headers.js
@@ -134,7 +134,6 @@ export function run(conf) {
   }
   conf.specType = conf.specType ? conf.specType.toUpperCase() : "";
 
-  conf.pubDomain = conf.pubDomain ? conf.pubDomain.toLowerCase() : "";
   conf.hasBeenPublished = !!conf.publishDate;
 
   conf.licenseInfo = conf.licenses[conf.license.toLowerCase()];


### PR DESCRIPTION
Door het volgende in de config te zetten zou de hoofdletters gespaard kunnen blijven: 

```js
keepCase: true,
```

closes #94 